### PR TITLE
Handle empty string in keyword casing utility

### DIFF
--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/ScriptGeneratorSupporter.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/ScriptGeneratorSupporter.cs
@@ -71,6 +71,16 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
         [SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase")]
         public static string GetPascalCase(string str)
         {
+            if (str == null)
+            {
+                throw new ArgumentNullException(nameof(str));
+            }
+
+            if (str.Length == 0)
+            {
+                return string.Empty;
+            }
+
             // Make the first letter upper case
             str = str.ToLowerInvariant();
             char firstLetter = Char.ToUpperInvariant(str[0]);

--- a/Test/SqlDom/ScriptGeneratorSupporterTests.cs
+++ b/Test/SqlDom/ScriptGeneratorSupporterTests.cs
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+// <copyright file="ScriptGeneratorSupporterTests.cs" company="Microsoft">
+//         Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlStudio.Tests.AssemblyTools.TestCategory;
+
+namespace SqlStudio.Tests.UTSqlScriptDom
+{
+    [TestClass]
+    public class ScriptGeneratorSupporterTests
+    {
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void GetPascalCase_ReturnsEmptyString_ForEmptyInput()
+        {
+            Assert.AreEqual(string.Empty, ScriptGeneratorSupporter.GetPascalCase(string.Empty));
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void GetPascalCase_ThrowsArgumentNullException_ForNullInput()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => ScriptGeneratorSupporter.GetPascalCase(null));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle null and empty strings in `GetPascalCase`
- add tests for edge cases in `ScriptGeneratorSupporter`

## Testing
- `dotnet test Test/SqlDom/UTSqlScriptDom.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e4f86f848326b2df28944c186cb9